### PR TITLE
bump base upper bound to <4.18

### DIFF
--- a/assoc.cabal
+++ b/assoc.cabal
@@ -42,7 +42,7 @@ library
   default-language: Haskell2010
   hs-source-dirs:   src
   build-depends:
-      base        >=4.3   && <4.17
+      base        >=4.3   && <4.18
     , bifunctors  >=5.5.5 && <5.6
     , tagged      >=0.8.6 && <0.9
 

--- a/src/Data/Bifunctor/Swap.hs
+++ b/src/Data/Bifunctor/Swap.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 module Data.Bifunctor.Swap (
     Swap (..),
     ) where


### PR DESCRIPTION
`TypeOperators` was added to silence `-Wtype-equality-requires-operators`